### PR TITLE
Fix widget tests using new TestUtil API

### DIFF
--- a/test/widget_test/ui/component/more_menu_icon_button_test.dart
+++ b/test/widget_test/ui/component/more_menu_icon_button_test.dart
@@ -8,11 +8,11 @@ void main() {
   group(
     'MoreMenuIconButton',
     () {
-      testGoldens(TestUtil.description('when it is normal state'), (tester) async {
-        await tester.testWidgetWithWidgetBuilder(
+      testGoldens('when it is normal state', (tester) async {
+        await tester.testWidget(
           filename: 'more_menu_icon_button/${TestUtil.filename('when_it_is_normal_state')}',
           widget: MoreMenuIconButton(onCopy: () {}, onReply: () {}),
-          mergeIntoSingleImage: false,
+          useMultiScreenGolden: true,
         );
       });
     },

--- a/test/widget_test/ui/component/primary_check_box_test.dart
+++ b/test/widget_test/ui/component/primary_check_box_test.dart
@@ -11,9 +11,9 @@ void main() {
     'PrimaryCheckBox',
     () {
       testGoldens(
-          TestUtil.description('when text is null and init value is false and isEnabled is false'),
+          'when text is null and init value is false and isEnabled is false',
           (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename:
               'primary_check_box/${TestUtil.filename('when_text_is_null_and_init_value_is_false_and_isEnabled_is_false')}',
           widget: const PrimaryCheckBox(
@@ -25,10 +25,9 @@ void main() {
       });
 
       testGoldens(
-          TestUtil.description(
-              'when text is not null and init value is true and isEnabled is true'),
+          'when text is not null and init value is true and isEnabled is true',
           (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename:
               'primary_check_box/${TestUtil.filename('when_text_is_not_null_and_init_value_is_true_and_isEnabled_is_true')}',
           widget: PrimaryCheckBox(
@@ -40,10 +39,9 @@ void main() {
       });
 
       testGoldens(
-          TestUtil.description(
-              'when text is not null and init value is true and isEnabled is false'),
+          'when text is not null and init value is true and isEnabled is false',
           (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename:
               'primary_check_box/${TestUtil.filename('when_text_is_not_null_and_init_value_is_true_and_isEnabled_is_false')}',
           widget: const PrimaryCheckBox(

--- a/test/widget_test/ui/component/primary_text_field_test.dart
+++ b/test/widget_test/ui/component/primary_text_field_test.dart
@@ -9,8 +9,8 @@ void main() {
   group(
     'PrimaryTextField',
     () {
-      testGoldens(TestUtil.description('when text is empty'), (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+      testGoldens('when text is empty', (tester) async {
+        await tester.testWidget(
           filename: 'primary_text_field/${TestUtil.filename('when_text_is_empty')}',
           widget: PrimaryTextField(
             title: 'Email',
@@ -20,8 +20,8 @@ void main() {
         );
       });
 
-      testGoldens(TestUtil.description('when text is not empty'), (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+      testGoldens('when text is not empty', (tester) async {
+        await tester.testWidget(
           filename: 'primary_text_field/${TestUtil.filename('when_text_is_not_empty')}',
           widget: PrimaryTextField(
             title: 'Email',
@@ -31,8 +31,8 @@ void main() {
         );
       });
 
-      testGoldens(TestUtil.description('when it has suffixIcon'), (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+      testGoldens('when it has suffixIcon', (tester) async {
+        await tester.testWidget(
           filename: 'primary_text_field/${TestUtil.filename('when_it_has_suffixIcon')}',
           widget: PrimaryTextField(
             title: 'Password',
@@ -47,9 +47,9 @@ void main() {
       });
 
       testGoldens(
-        TestUtil.description('when keyboardType is TextInputType.visiblePassword'),
+        'when keyboardType is TextInputType.visiblePassword',
         (tester) async {
-          await tester.testWidgetWithDeviceBuilder(
+          await tester.testWidget(
             filename:
                 'primary_text_field/${TestUtil.filename('when_keyboardType_is_TextInputType.visiblePassword')}',
             widget: PrimaryTextField(
@@ -63,9 +63,9 @@ void main() {
       );
 
       testGoldens(
-        TestUtil.description('when tapping on the eye icon once'),
+        'when tapping on the eye icon once',
         (tester) async {
-          await tester.testWidgetWithDeviceBuilder(
+          await tester.testWidget(
             filename:
                 'primary_text_field/${TestUtil.filename('when_tapping_on_the_eye_icon_once')}',
             widget: PrimaryTextField(
@@ -74,9 +74,8 @@ void main() {
               controller: TextEditingController(text: '123456'),
               keyboardType: TextInputType.visiblePassword,
             ),
-            onCreate: (tester, key) async {
-              final eyeIconFinder =
-                  find.byType(GestureDetector).isDescendantOf(find.byKey(key), find);
+            onCreate: (tester) async {
+              final eyeIconFinder = find.byType(GestureDetector);
 
               expect(eyeIconFinder, findsOneWidget);
 

--- a/test/widget_test/ui/component/search_text_field_test.dart
+++ b/test/widget_test/ui/component/search_text_field_test.dart
@@ -9,19 +9,19 @@ void main() {
   group(
     'SearchTextField',
     () {
-      testGoldens(TestUtil.description('when text is empty'), (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+      testGoldens('when text is empty', (tester) async {
+        await tester.testWidget(
           filename: 'search_text_field/${TestUtil.filename('when_text_is_empty')}',
           widget: const SearchTextField(),
         );
       });
 
-      testGoldens(TestUtil.description('when text is not empty'), (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+      testGoldens('when text is not empty', (tester) async {
+        await tester.testWidget(
           filename: 'search_text_field/${TestUtil.filename('when_text_is_not_empty')}',
           widget: const SearchTextField(),
-          onCreate: (tester, key) async {
-            final textFieldFinder = find.byType(TextField).isDescendantOf(find.byKey(key), find);
+          onCreate: (tester) async {
+            final textFieldFinder = find.byType(TextField);
             expect(textFieldFinder, findsOneWidget);
 
             await tester.enterText(textFieldFinder, 'ntminh');

--- a/test/widget_test/ui/page/all_users/all_users_page_test.dart
+++ b/test/widget_test/ui/page/all_users/all_users_page_test.dart
@@ -16,8 +16,7 @@ class MockAllUsersViewModel extends StateNotifier<CommonState<AllUsersState>>
 void main() {
   group('AllUsersPage', () {
     testGoldens(
-      TestUtil.description(
-          'when all users is not empty and members is empty and add button is enabled'),
+      'when all users is not empty and members is empty and add button is enabled',
       (tester) async {
         const selectedUserId = '1';
         final vm = MockAllUsersViewModel(
@@ -35,7 +34,7 @@ void main() {
         when(() => vm.isUserChecked(selectedUserId)).thenReturn(true);
         when(() => vm.isUserChecked('2')).thenReturn(false);
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename:
               'all_users_page/${TestUtil.filename('when_all_users_is_not_empty_and_members_is_empty_and_add_button_is_enabled')}',
           widget: const AllUsersPage(action: AllUsersPageAction.createNewConversation),
@@ -49,8 +48,7 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description(
-          'when all users is empty and members is empty and add button is disabled'),
+      'when all users is empty and members is empty and add button is disabled',
       (tester) async {
         final vm = MockAllUsersViewModel(
           const CommonState(
@@ -58,7 +56,7 @@ void main() {
           ),
         );
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename:
               'all_users_page/${TestUtil.filename('when_all_users_is_empty_and_members_is_empty_and_add_button_is_disabled')}',
           widget: const AllUsersPage(action: AllUsersPageAction.createNewConversation),
@@ -72,8 +70,7 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description(
-          'when members is not empty and all users is not empty and add button is enabled'),
+      'when members is not empty and all users is not empty and add button is enabled',
       (tester) async {
         const selectedUserId = '1';
         const me = FirebaseConversationUserData(userId: '3', email: 'thinhnd');
@@ -100,7 +97,7 @@ void main() {
         when(() => vm.isConversationUserChecked(me.userId)).thenReturn(true);
         when(() => vm.isConversationUserChecked(any(that: isNot(me.userId)))).thenReturn(false);
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename:
               'all_users_page/${TestUtil.filename('when_members_is_not_empty_and_all_users_is_not_empty_and_add_button_is_enabled')}',
           widget: const AllUsersPage(action: AllUsersPageAction.addMembers),
@@ -118,8 +115,7 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description(
-          'when members is not empty and all users is empty and add button is disabled'),
+      'when members is not empty and all users is empty and add button is disabled',
       (tester) async {
         const me = FirebaseConversationUserData(userId: '3', email: 'thinhnd');
         final vm = MockAllUsersViewModel(
@@ -136,12 +132,12 @@ void main() {
 
         when(() => vm.isConversationUserChecked(any())).thenReturn(true);
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename:
               'all_users_page/${TestUtil.filename('when_members_is_not_empty_and_all_users_is_empty_and_add_button_is_disabled')}',
           widget: const AllUsersPage(action: AllUsersPageAction.addMembers),
-          onCreate: (tester, key) async {
-            final textFieldFinder = find.byType(TextField).isDescendantOf(find.byKey(key), find);
+          onCreate: (tester) async {
+            final textFieldFinder = find.byType(TextField);
             expect(textFieldFinder, findsExactly(1));
 
             await tester.enterText(

--- a/test/widget_test/ui/page/chat/chat_page_test.dart
+++ b/test/widget_test/ui/page/chat/chat_page_test.dart
@@ -17,7 +17,7 @@ class MockChatViewModel extends StateNotifier<CommonState<ChatState>>
 void main() {
   group('ChatPage', () {
     testGoldens(
-      TestUtil.description('when `messages` is empty'),
+      'when `messages` is empty',
       (tester) async {
         const currentUserId = '1';
         const members = [
@@ -37,7 +37,7 @@ void main() {
           email: 'ntminhdn@gmail.com',
         );
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'chat_page/${TestUtil.filename('when_messages_is_empty')}',
           widget: const ChatPage(conversation: conversation),
           overrides: [
@@ -64,7 +64,7 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when `messages` is not empty'),
+      'when `messages` is not empty',
       (tester) async {
         const currentUserId = '1';
         const thinhId = '2';
@@ -97,7 +97,7 @@ void main() {
           email: 'ntminhdn@gmail.com',
         );
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'chat_page/${TestUtil.filename('when_messages_is_not_empty')}',
           widget: const ChatPage(conversation: conversation),
           overrides: [
@@ -219,7 +219,7 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when user is typing'),
+      'when user is typing',
       (tester) async {
         const currentUserId = '1';
         const members = [
@@ -239,11 +239,11 @@ void main() {
           email: 'ntminhdn@gmail.com',
         );
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'chat_page/${TestUtil.filename('when_user_is_typing')}',
           widget: const ChatPage(conversation: conversation),
-          onCreate: (tester, key) async {
-            final textFieldFinder = find.byType(TextField).isDescendantOf(find.byKey(key), find);
+          onCreate: (tester) async {
+            final textFieldFinder = find.byType(TextField);
             expect(textFieldFinder, findsOneWidget);
 
             await tester.enterText(textFieldFinder, 'dog and cat');
@@ -272,7 +272,7 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when users are replying themselves'),
+      'when users are replying themselves',
       (tester) async {
         const currentUserId = '1';
         const members = [
@@ -292,13 +292,12 @@ void main() {
           email: 'duynn@gmail.com',
         );
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'chat_page/${TestUtil.filename('when_users_are_replying_themselves')}',
           widget: const ChatPage(conversation: conversation),
-          onCreate: (tester, key) async {
+          onCreate: (tester) async {
             await tester.pump(5.seconds);
-            final moreMenuIconFinder =
-                find.byType(MoreMenuIconButton).isDescendantOf(find.byKey(key), find);
+            final moreMenuIconFinder = find.byType(MoreMenuIconButton);
             expect(moreMenuIconFinder, findsOneWidget);
             await tester.tap(moreMenuIconFinder);
             await tester.pump();
@@ -338,7 +337,7 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when users are replying to other users'),
+      'when users are replying to other users',
       (tester) async {
         const currentUserId = '1';
         const otherUserId = '2';
@@ -363,13 +362,12 @@ void main() {
           email: 'duynn@gmail.com',
         );
 
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'chat_page/${TestUtil.filename('when_users_are_replying_to_other_users')}',
           widget: const ChatPage(conversation: conversation),
-          onCreate: (tester, key) async {
+          onCreate: (tester) async {
             await tester.pump(5.seconds);
-            final moreMenuIconFinder =
-                find.byType(MoreMenuIconButton).isDescendantOf(find.byKey(key), find);
+            final moreMenuIconFinder = find.byType(MoreMenuIconButton);
             expect(moreMenuIconFinder, findsOneWidget);
             await tester.tap(moreMenuIconFinder);
             await tester.pump();
@@ -408,7 +406,7 @@ void main() {
       },
     );
 
-    testGoldens(TestUtil.description('when displaying the menu'), (tester) async {
+    testGoldens('when displaying the menu', (tester) async {
       const currentUserId = '1';
       const members = [
         FirebaseConversationUserData(
@@ -428,15 +426,15 @@ void main() {
       );
       const message = 'Hello';
 
-      await tester.testWidgetWithDeviceBuilder(
+      await tester.testWidget(
         filename: 'chat_page/${TestUtil.filename('when_displaying_the_menu')}',
         widget: const ChatPage(conversation: conversation),
-        onCreate: (tester, key) async {
+        onCreate: (tester) async {
           await tester.pump(5.seconds);
           final menuFinder = find
               .byType(IconButton)
               .isAncestorOf(find.byType(AnimatedIcon), find)
-              .isDescendantOf(find.byKey(key), find);
+              .isDescendantOf(find.byType(ChatPage), find);
           await tester.tap(menuFinder);
           await tester.pumpAndSettle();
         },

--- a/test/widget_test/ui/page/contact_list/contact_list_page_test.dart
+++ b/test/widget_test/ui/page/contact_list/contact_list_page_test.dart
@@ -16,9 +16,9 @@ class MockContactListViewModel extends StateNotifier<CommonState<ContactListStat
 void main() {
   group('ContactListPage', () {
     testGoldens(
-      TestUtil.description('when conversationList is empty'),
+      'when conversationList is empty',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'contact_list_page/${TestUtil.filename('when_conversationList_is_empty')}',
           widget: const ContactListPage(),
           overrides: [
@@ -39,13 +39,13 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when conversationList is not empty'),
+      'when conversationList is not empty',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'contact_list_page/${TestUtil.filename('when_conversationList_is_not_empty')}',
           widget: const ContactListPage(),
-          onCreate: (tester, key) async {
-            final textFieldFinder = find.byType(TextField).isDescendantOf(find.byKey(key), find);
+          onCreate: (tester) async {
+            final textFieldFinder = find.byType(TextField);
             expect(textFieldFinder, findsOneWidget);
 
             await tester.enterText(textFieldFinder, 'dog');
@@ -74,9 +74,9 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when current user is vip member'),
+      'when current user is vip member',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'contact_list_page/${TestUtil.filename('when_current_user_is_vip_member')}',
           widget: const ContactListPage(),
           overrides: [

--- a/test/widget_test/ui/page/home/home_page_test.dart
+++ b/test/widget_test/ui/page/home/home_page_test.dart
@@ -28,7 +28,7 @@ HomeViewModel _buildHomeViewModel(CommonState<HomeState> state) {
 void main() {
   group('HomePage', () {
     testGoldens(
-      TestUtil.description('when fetching background image failed'),
+      'when fetching background image failed',
       (tester) async {
         await runZonedGuarded(
           () async {
@@ -42,7 +42,7 @@ void main() {
               oldCallback?.call(details);
             };
 
-            await tester.testWidgetWithDeviceBuilder(
+            await tester.testWidget(
               filename: 'home_page/${TestUtil.filename('when_fetching_background_image_failed')}',
               widget: HomePage(cacheManager: MockInvalidCacheManager()),
               overrides: [
@@ -63,9 +63,9 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when `isShimmerLoading` is true'),
+      'when `isShimmerLoading` is true',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'home_page/${TestUtil.filename('when_isShimmerLoading_is_true')}',
           widget: HomePage(cacheManager: MockCacheManager()),
           overrides: [
@@ -85,9 +85,9 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when `users` is empty'),
+      'when `users` is empty',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'home_page/${TestUtil.filename('when_users_is_empty')}',
           widget: HomePage(cacheManager: MockCacheManager()),
           overrides: [
@@ -105,15 +105,15 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when `users` is not empty'),
+      'when `users` is not empty',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'home_page/${TestUtil.filename('when_users_is_not_empty')}',
           widget: HomePage(cacheManager: MockCacheManager()),
-          onCreate: (tester, key) async {
+          onCreate: (tester) async {
             await tester.pump(30.seconds);
             final widget = tester.widget<CommonPagedListView<ApiUserData>>(
-              find.byType(CommonPagedListView<ApiUserData>).isDescendantOf(find.byKey(key), find),
+              find.byType(CommonPagedListView<ApiUserData>),
             );
             when(
               () => widget.pagingController.fetchPage(

--- a/test/widget_test/ui/page/login/login_page_test.dart
+++ b/test/widget_test/ui/page/login/login_page_test.dart
@@ -17,9 +17,9 @@ void main() {
     'LoginPage',
     () {
       testGoldens(
-        TestUtil.description('when login button is disabled'),
+        'when login button is disabled',
         (tester) async {
-          await tester.testWidgetWithDeviceBuilder(
+          await tester.testWidget(
             filename: 'login_page/${TestUtil.filename('when_login_button_is_disabled')}',
             widget: const LoginPage(),
             overrides: [
@@ -35,14 +35,13 @@ void main() {
       );
 
       testGoldens(
-        TestUtil.description('when login button is enabled'),
+        'when login button is enabled',
         (tester) async {
-          await tester.testWidgetWithDeviceBuilder(
+          await tester.testWidget(
             filename: 'login_page/${TestUtil.filename('when_login_button_is_enabled')}',
             widget: const LoginPage(),
-            onCreate: (tester, key) async {
-              final primaryTextFieldFinder =
-                  find.byType(PrimaryTextField).isDescendantOf(find.byKey(key), find);
+            onCreate: (tester) async {
+              final primaryTextFieldFinder = find.byType(PrimaryTextField);
               expect(primaryTextFieldFinder, findsExactly(2));
               final emailTextField = primaryTextFieldFinder.first;
               final passwordTextField = primaryTextFieldFinder.at(1);
@@ -70,9 +69,9 @@ void main() {
       );
 
       testGoldens(
-        TestUtil.description('when error text is visible'),
+        'when error text is visible',
         (tester) async {
-          await tester.testWidgetWithDeviceBuilder(
+          await tester.testWidget(
             filename: 'login_page/${TestUtil.filename('when_error_text_is_visible')}',
             widget: const LoginPage(),
             overrides: [

--- a/test/widget_test/ui/page/main/main_page_test.dart
+++ b/test/widget_test/ui/page/main/main_page_test.dart
@@ -24,7 +24,7 @@ void main() {
   });
 
   group('MainPage', () {
-    testGoldens(TestUtil.description('when current bottom navigation index is 0'), (tester) async {
+    testGoldens('when current bottom navigation index is 0', (tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidgetBuilder(
           ProviderScope(
@@ -68,7 +68,7 @@ void main() {
       );
     });
 
-    testGoldens(TestUtil.description('when current bottom navigation index is 1'), (tester) async {
+    testGoldens('when current bottom navigation index is 1', (tester) async {
       await tester.runAsync(() async {
         await tester.pumpWidgetBuilder(
           ProviderScope(

--- a/test/widget_test/ui/page/my_page/my_page_page_test.dart
+++ b/test/widget_test/ui/page/my_page/my_page_page_test.dart
@@ -15,9 +15,9 @@ class MockMyPageViewModel extends StateNotifier<CommonState<MyPageState>>
 void main() {
   group('MyPagePage', () {
     testGoldens(
-      TestUtil.description('when current user is not vip member'),
+      'when current user is not vip member',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'my_page_page/${TestUtil.filename('when_current_user_is_not_vip_member')}',
           widget: const MyPagePage(),
           overrides: [
@@ -38,9 +38,9 @@ void main() {
     );
 
     testGoldens(
-      TestUtil.description('when current user is vip member'),
+      'when current user is vip member',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'my_page_page/${TestUtil.filename('when_current_user_is_vip_member')}',
           widget: const MyPagePage(),
           overrides: [

--- a/test/widget_test/ui/page/register/register_page_test.dart
+++ b/test/widget_test/ui/page/register/register_page_test.dart
@@ -17,9 +17,9 @@ void main() {
     'RegisterPage',
     () {
       testGoldens(
-        TestUtil.description('when register button is disabled'),
+        'when register button is disabled',
         (tester) async {
-          await tester.testWidgetWithDeviceBuilder(
+          await tester.testWidget(
             filename: 'register_page/${TestUtil.filename('when_register_button_is_disabled')}',
             widget: const RegisterPage(),
             overrides: [
@@ -37,14 +37,13 @@ void main() {
       );
 
       testGoldens(
-        TestUtil.description('when register button is enabled'),
+        'when register button is enabled',
         (tester) async {
-          await tester.testWidgetWithDeviceBuilder(
+          await tester.testWidget(
             filename: 'register_page/${TestUtil.filename('when_register_button_is_enabled')}',
             widget: const RegisterPage(),
-            onCreate: (tester, key) async {
-              final primaryTextFieldFinder =
-                  find.byType(PrimaryTextField).isDescendantOf(find.byKey(key), find);
+            onCreate: (tester) async {
+              final primaryTextFieldFinder = find.byType(PrimaryTextField);
               expect(primaryTextFieldFinder, findsExactly(3));
               final emailTextField = primaryTextFieldFinder.first;
               final passwordTextField = primaryTextFieldFinder.at(1);
@@ -75,9 +74,9 @@ void main() {
       );
 
       testGoldens(
-        TestUtil.description('when error text is visible'),
+        'when error text is visible',
         (tester) async {
-          await tester.testWidgetWithDeviceBuilder(
+          await tester.testWidget(
             filename: 'register_page/${TestUtil.filename('when_error_text_is_visible')}',
             widget: const RegisterPage(),
             overrides: [

--- a/test/widget_test/ui/page/rename_conversation/rename_conversation_page_test.dart
+++ b/test/widget_test/ui/page/rename_conversation/rename_conversation_page_test.dart
@@ -17,9 +17,9 @@ void main() {
     const conversation = FirebaseConversationData(id: '1');
 
     testGoldens(
-      TestUtil.description('when members is empty'),
+      'when members is empty',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'rename_conversation_page/${TestUtil.filename('when_members_is_empty')}',
           widget: const RenameConversationPage(conversation: conversation),
           overrides: [
@@ -39,9 +39,9 @@ void main() {
       },
     );
     testGoldens(
-      TestUtil.description('when members is not empty'),
+      'when members is not empty',
       (tester) async {
-        await tester.testWidgetWithDeviceBuilder(
+        await tester.testWidget(
           filename: 'rename_conversation_page/${TestUtil.filename('when_members_is_not_empty')}',
           widget: const RenameConversationPage(conversation: conversation),
           overrides: [

--- a/test/widget_test/ui/page/setting/setting_page_test.dart
+++ b/test/widget_test/ui/page/setting/setting_page_test.dart
@@ -17,10 +17,9 @@ void main() {
     group('test', () {
       void _baseTestGoldens(LanguageCode languageCode) {
         testGoldens(
-          TestUtil.description(
-              'when theme is ${TestConfig.isDarkMode ? 'dark' : 'light'} and language is $languageCode'),
+          'when theme is ${TestConfig.isDarkMode ? 'dark' : 'light'} and language is $languageCode',
           (tester) async {
-            await tester.testWidgetWithDeviceBuilder(
+            await tester.testWidget(
               filename:
                   'setting/${TestUtil.filename('when_theme_is_${TestConfig.isDarkMode ? 'dark' : 'light'}_and_language_is_$languageCode')}',
               widget: const SettingPage(),


### PR DESCRIPTION
## Summary
- update widget tests to use `testWidget` and new descriptions
- remove deprecated `testWidgetWithDeviceBuilder` usages
- simplify onCreate callbacks

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452a82380c8326858f6bd232e59d64