### PR TITLE
Add lint for mismatched Freezed default value

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -141,6 +141,7 @@ custom_lint:
       includes:
         - "apps/**/lib/ui/*.dart"
         - "apps/**/lib/ui/**/*.dart"
+    - incorrect_freezed_default_value_type:
 
 linter:
   rules:

--- a/lib/ui/page/chat/view_model/chat_state.dart
+++ b/lib/ui/page/chat/view_model/chat_state.dart
@@ -10,7 +10,7 @@ sealed class ChatState extends BaseState with _$ChatState {
 
   const factory ChatState({
     required FirebaseConversationData conversation,
-    @Default([]) List<LocalMessageData> messages,
+    @Default(<LocalMessageData>[]) List<LocalMessageData> messages,
     @Default(false) bool isLastPage,
     @Default(false) bool isAdmin,
   }) = _ChatState;

--- a/super_lint/CHANGELOG.md
+++ b/super_lint/CHANGELOG.md
@@ -1,4 +1,3 @@
 ## 1.0.0
 
 - Initial version.
-- Add incorrect_freezed_default_value_type lint.

--- a/super_lint/CHANGELOG.md
+++ b/super_lint/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 1.0.0
 
 - Initial version.
+- Add incorrect_freezed_default_value_type lint.

--- a/super_lint/doc/LINTS.md
+++ b/super_lint/doc/LINTS.md
@@ -14,6 +14,7 @@
   - [prefer_async_await](#prefer_async_await)
   - [prefer_lower_case_test_description](#prefer_lower_case_test_description)
   - [test_folder_must_mirror_lib_folder](#test_folder_must_mirror_lib_folder)
+  - [incorrect_freezed_default_value_type](#incorrect_freezed_default_value_type)
 
 ## All lint rules
 
@@ -362,4 +363,24 @@ stateNotifierTest('Uppercase text', () {});
 test('uppercase text', () {});
 
 blocTest('Uppercase text', () {});
+```
+
+### incorrect_freezed_default_value_type
+
+The value passed to `@Default()` in a freezed class must have a compatible type with the annotated field.
+
+```yaml
+- incorrect_freezed_default_value_type:
+```
+
+**Good**:
+
+```dart
+@Default(<ApiUserData>[]) List<ApiUserData> allContacts,
+```
+
+**Bad**:
+
+```dart
+@Default(0) List<ApiUserData> allContacts,
 ```

--- a/super_lint/doc/LINTS.md
+++ b/super_lint/doc/LINTS.md
@@ -15,6 +15,28 @@
   - [prefer_lower_case_test_description](#prefer_lower_case_test_description)
   - [test_folder_must_mirror_lib_folder](#test_folder_must_mirror_lib_folder)
   - [incorrect_freezed_default_value_type](#incorrect_freezed_default_value_type)
+  - [prefer_single_widget_per_file](#prefer_single_widget_per_file)
+  - [util_functions_must_be_static](#util_functions_must_be_static)
+  - [missing_extension_method_for_events](#missing_extension_method_for_events)
+  - [missing_log_in_catch_block](#missing_log_in_catch_block)
+  - [missing_run_catching](#missing_run_catching)
+  - [incorrect_event_parameter_type](#incorrect_event_parameter_type)
+  - [incorrect_screen_name_enum_value](#incorrect_screen_name_enum_value)
+  - [incorrect_screen_name_parameter_value](#incorrect_screen_name_parameter_value)
+  - [missing_common_scrollbar](#missing_common_scrollbar)
+  - [avoid_using_text_style_constructor_directly](#avoid_using_text_style_constructor_directly)
+  - [avoid_using_unsafe_cast](#avoid_using_unsafe_cast)
+  - [incorrect_event_name](#incorrect_event_name)
+  - [incorrect_event_parameter_name](#incorrect_event_parameter_name)
+  - [avoid_dynamic](#avoid_dynamic)
+  - [avoid_nested_conditions](#avoid_nested_conditions)
+  - [avoid_using_if_else_with_enums](#avoid_using_if_else_with_enums)
+  - [avoid_hard_coded_colors](#avoid_hard_coded_colors)
+  - [prefer_importing_index_file](#prefer_importing_index_file)
+  - [prefer_common_widgets](#prefer_common_widgets)
+  - [missing_expanded_or_flexible](#missing_expanded_or_flexible)
+  - [incorrect_parent_class](#incorrect_parent_class)
+  - [avoid_hard_coded_strings](#avoid_hard_coded_strings)
 
 ## All lint rules
 
@@ -383,4 +405,574 @@ The value passed to `@Default()` in a freezed class must have a compatible type 
 
 ```dart
 @Default(0) List<ApiUserData> allContacts,
+```
+
+### prefer_single_widget_per_file
+
+Each file should contain only one widget class.
+
+```yaml
+- prefer_single_widget_per_file:
+```
+
+**Good**:
+
+```dart
+// home_screen.dart
+class HomeScreen extends StatelessWidget {
+  // ...
+}
+```
+
+**Bad**:
+
+```dart
+// screens.dart
+class HomeScreen extends StatelessWidget {
+  // ...
+}
+
+class ProfileScreen extends StatelessWidget {
+  // ...
+}
+```
+
+### util_functions_must_be_static
+
+Utility functions should be static.
+
+```yaml
+- util_functions_must_be_static:
+```
+
+**Good**:
+
+```dart
+class StringUtils {
+  static String capitalize(String text) {
+    return text.toUpperCase();
+  }
+}
+```
+
+**Bad**:
+
+```dart
+class StringUtils {
+  String capitalize(String text) {
+    return text.toUpperCase();
+  }
+}
+```
+
+### missing_extension_method_for_events
+
+Events should have corresponding extension methods.
+
+```yaml
+- missing_extension_method_for_events:
+```
+
+**Good**:
+
+```dart
+class LoginEvent {}
+
+extension LoginEventExtension on LoginEvent {
+  void handle() {
+    // ...
+  }
+}
+```
+
+**Bad**:
+
+```dart
+class LoginEvent {}
+```
+
+### missing_log_in_catch_block
+
+Catch blocks should include logging.
+
+```yaml
+- missing_log_in_catch_block:
+```
+
+**Good**:
+
+```dart
+try {
+  // ...
+} catch (e) {
+  log('Error occurred: $e');
+  rethrow;
+}
+```
+
+**Bad**:
+
+```dart
+try {
+  // ...
+} catch (e) {
+  rethrow;
+}
+```
+
+### missing_run_catching
+
+Use runCatching for error handling.
+
+```yaml
+- missing_run_catching:
+```
+
+**Good**:
+
+```dart
+final result = runCatching(() {
+  return someFunction();
+});
+```
+
+**Bad**:
+
+```dart
+try {
+  final result = someFunction();
+} catch (e) {
+  // handle error
+}
+```
+
+### incorrect_event_parameter_type
+
+Event parameters should have correct types.
+
+```yaml
+- incorrect_event_parameter_type:
+```
+
+**Good**:
+
+```dart
+class LoginEvent {
+  final String username;
+  final String password;
+}
+```
+
+**Bad**:
+
+```dart
+class LoginEvent {
+  final dynamic username;
+  final dynamic password;
+}
+```
+
+### incorrect_screen_name_enum_value
+
+Screen name enum values should follow naming conventions.
+
+```yaml
+- incorrect_screen_name_enum_value:
+```
+
+**Good**:
+
+```dart
+enum ScreenName {
+  home,
+  profile,
+  settings,
+}
+```
+
+**Bad**:
+
+```dart
+enum ScreenName {
+  Home,
+  Profile,
+  Settings,
+}
+```
+
+### incorrect_screen_name_parameter_value
+
+Screen name parameter values should match enum values.
+
+```yaml
+- incorrect_screen_name_parameter_value:
+```
+
+**Good**:
+
+```dart
+navigateTo(ScreenName.home);
+```
+
+**Bad**:
+
+```dart
+navigateTo('Home');
+```
+
+### missing_common_scrollbar
+
+Use common scrollbar widget for scrollable content.
+
+```yaml
+- missing_common_scrollbar:
+```
+
+**Good**:
+
+```dart
+CommonScrollbar(
+  child: ListView(
+    children: [...],
+  ),
+)
+```
+
+**Bad**:
+
+```dart
+ListView(
+  children: [...],
+)
+```
+
+### avoid_using_text_style_constructor_directly
+
+Use predefined text styles instead of direct TextStyle constructor.
+
+```yaml
+- avoid_using_text_style_constructor_directly:
+```
+
+**Good**:
+
+```dart
+Text(
+  'Hello',
+  style: AppTextStyles.heading,
+)
+```
+
+**Bad**:
+
+```dart
+Text(
+  'Hello',
+  style: TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.bold,
+  ),
+)
+```
+
+### avoid_using_unsafe_cast
+
+Avoid unsafe type casting.
+
+```yaml
+- avoid_using_unsafe_cast:
+```
+
+**Good**:
+
+```dart
+if (value is String) {
+  final stringValue = value;
+  // use stringValue
+}
+```
+
+**Bad**:
+
+```dart
+final stringValue = value as String;
+```
+
+### incorrect_event_name
+
+Event names should follow naming conventions.
+
+```yaml
+- incorrect_event_name:
+```
+
+**Good**:
+
+```dart
+class UserLoggedInEvent {}
+```
+
+**Bad**:
+
+```dart
+class userLoggedIn {}
+```
+
+### incorrect_event_parameter_name
+
+Event parameter names should follow naming conventions.
+
+```yaml
+- incorrect_event_parameter_name:
+```
+
+**Good**:
+
+```dart
+class LoginEvent {
+  final String username;
+  final String password;
+}
+```
+
+**Bad**:
+
+```dart
+class LoginEvent {
+  final String user_name;
+  final String pwd;
+}
+```
+
+### avoid_dynamic
+
+Avoid using dynamic type.
+
+```yaml
+- avoid_dynamic:
+```
+
+**Good**:
+
+```dart
+String getValue() {
+  return 'value';
+}
+```
+
+**Bad**:
+
+```dart
+dynamic getValue() {
+  return 'value';
+}
+```
+
+### avoid_nested_conditions
+
+Avoid deeply nested conditions.
+
+```yaml
+- avoid_nested_conditions:
+```
+
+**Good**:
+
+```dart
+if (!isValid) return;
+if (!isEnabled) return;
+if (!hasPermission) return;
+// proceed with logic
+```
+
+**Bad**:
+
+```dart
+if (isValid) {
+  if (isEnabled) {
+    if (hasPermission) {
+      // proceed with logic
+    }
+  }
+}
+```
+
+### avoid_using_if_else_with_enums
+
+Use switch statements with enums instead of if-else.
+
+```yaml
+- avoid_using_if_else_with_enums:
+```
+
+**Good**:
+
+```dart
+switch (status) {
+  case Status.active:
+    return 'Active';
+  case Status.inactive:
+    return 'Inactive';
+  case Status.pending:
+    return 'Pending';
+}
+```
+
+**Bad**:
+
+```dart
+if (status == Status.active) {
+  return 'Active';
+} else if (status == Status.inactive) {
+  return 'Inactive';
+} else {
+  return 'Pending';
+}
+```
+
+### avoid_hard_coded_colors
+
+Use color constants instead of hard-coded colors.
+
+```yaml
+- avoid_hard_coded_colors:
+```
+
+**Good**:
+
+```dart
+Container(
+  color: AppColors.primary,
+)
+```
+
+**Bad**:
+
+```dart
+Container(
+  color: Color(0xFF000000),
+)
+```
+
+### prefer_importing_index_file
+
+Import from index files instead of individual files.
+
+```yaml
+- prefer_importing_index_file:
+```
+
+**Good**:
+
+```dart
+import 'package:my_app/features/auth/index.dart';
+```
+
+**Bad**:
+
+```dart
+import 'package:my_app/features/auth/login_screen.dart';
+import 'package:my_app/features/auth/register_screen.dart';
+```
+
+### prefer_common_widgets
+
+Use common widgets instead of basic Flutter widgets.
+
+```yaml
+- prefer_common_widgets:
+```
+
+**Good**:
+
+```dart
+CommonButton(
+  onPressed: () {},
+  child: Text('Click me'),
+)
+```
+
+**Bad**:
+
+```dart
+ElevatedButton(
+  onPressed: () {},
+  child: Text('Click me'),
+)
+```
+
+### missing_expanded_or_flexible
+
+Use Expanded or Flexible for widgets in Row/Column.
+
+```yaml
+- missing_expanded_or_flexible:
+```
+
+**Good**:
+
+```dart
+Row(
+  children: [
+    Expanded(
+      child: Text('Long text'),
+    ),
+    Icon(Icons.star),
+  ],
+)
+```
+
+**Bad**:
+
+```dart
+Row(
+  children: [
+    Text('Long text'),
+    Icon(Icons.star),
+  ],
+)
+```
+
+### incorrect_parent_class
+
+Widgets should extend the correct parent class.
+
+```yaml
+- incorrect_parent_class:
+```
+
+**Good**:
+
+```dart
+class MyScreen extends StatelessWidget {
+  // ...
+}
+```
+
+**Bad**:
+
+```dart
+class MyScreen extends StatefulWidget {
+  // Should be StatelessWidget
+}
+```
+
+### avoid_hard_coded_strings
+
+Use string constants instead of hard-coded strings.
+
+```yaml
+- avoid_hard_coded_strings:
+```
+
+**Good**:
+
+```dart
+Text(AppStrings.welcomeMessage)
+```
+
+**Bad**:
+
+```dart
+Text('Welcome to the app!')
 ```

--- a/super_lint/example/analysis_options.yaml
+++ b/super_lint/example/analysis_options.yaml
@@ -74,3 +74,5 @@ custom_lint:
         - "integration_test/*.dart"
         - "integration_test/**/*.dart"
       common_scrollbar_widget_name: "CommonScrollbar"
+    - incorrect_freezed_default_value_type:
+      severity: warning

--- a/super_lint/example/lib/incorrect_freezed_default_value_type_test.dart
+++ b/super_lint/example/lib/incorrect_freezed_default_value_type_test.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: avoid_hard_coded_strings
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'incorrect_freezed_default_value_type_test.freezed.dart';
+
+@freezed
+class User with _$User {
+  const factory User({
+    @Default(<String>[]) List<String> names,
+  }) = _User;
+}
+
+@freezed
+class Contact with _$Contact {
+  const factory Contact({
+    // expect_lint: incorrect_freezed_default_value_type
+    @Default(0) List<String> phones,
+  }) = _Contact;
+}

--- a/super_lint/example/lib/incorrect_freezed_default_value_type_test.dart
+++ b/super_lint/example/lib/incorrect_freezed_default_value_type_test.dart
@@ -1,20 +1,150 @@
-// ignore_for_file: avoid_hard_coded_strings
-
+// ignore_for_file: avoid_hard_coded_strings,prefer_single_widget_per_file
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-part 'incorrect_freezed_default_value_type_test.freezed.dart';
-
-@freezed
-class User with _$User {
+class User {
   const factory User({
-    @Default(<String>[]) List<String> names,
+    @Default(<String>[]) List<String> list,
+    @Default(<String>{}) Set<String> set1,
+    @Default(<String, String>{}) Map<String, String> map,
+    @Default('') String string,
+    @Default(0) int integer,
+    @Default(0.0) double decimal,
+    @Default(0.0) num num1,
+    @Default(false) bool boolean,
+    @Default(null) DateTime? dateTime,
+    @Default(DemoObject()) DemoObject demoObject,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default(0) List<String> list2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default('') Set<String> set2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default(null) Map<String, String> map2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default('') int string2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default(0) bool integer2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default(0.0) String decimal2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default(0.0) int num2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default(false) num boolean2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default(null) DemoObject dateTime2,
+    //expect_lint: incorrect_freezed_default_value_type
+    @Default(DemoObject()) DemoObject2 demoObject2,
   }) = _User;
 }
 
-@freezed
-class Contact with _$Contact {
-  const factory Contact({
-    // expect_lint: incorrect_freezed_default_value_type
-    @Default(0) List<String> phones,
-  }) = _Contact;
+class _User implements User {
+  const _User({
+    List<String>? list,
+    Set<String>? set1,
+    Map<String, String>? map,
+    String? string,
+    int? integer,
+    double? decimal,
+    num? num1,
+    bool? boolean,
+    DateTime? dateTime,
+    DemoObject? demoObject,
+    List<String>? list2,
+    Set<String>? set2,
+    Map<String, String>? map2,
+    int? string2,
+    bool? integer2,
+    String? decimal2,
+    int? num2,
+    num? boolean2,
+    DemoObject? dateTime2,
+    DemoObject2? demoObject2,
+  })  : _list = list ?? const <String>[],
+        _set1 = set1 ?? const <String>{},
+        _map = map ?? const <String, String>{},
+        _string = string ?? '',
+        _integer = integer ?? 0,
+        _decimal = decimal ?? 0.0,
+        _num1 = num1 ?? 0.0,
+        _boolean = boolean ?? false,
+        _dateTime = dateTime,
+        _demoObject = demoObject ?? const DemoObject(),
+        _list2 = list2 ?? const <String>[],
+        _set2 = set2 ?? const <String>{},
+        _map2 = map2 ?? const <String, String>{},
+        _string2 = string2 ?? 1,
+        _integer2 = integer2 ?? false,
+        _decimal2 = decimal2 ?? '',
+        _num2 = num2 ?? 0,
+        _boolean2 = boolean2 ?? 1,
+        _dateTime2 = dateTime2,
+        _demoObject2 = demoObject2 ?? const DemoObject2();
+
+  final List<String> _list;
+  final Set<String> _set1;
+  final Map<String, String> _map;
+  final String _string;
+  final int _integer;
+  final double _decimal;
+  final num _num1;
+  final bool _boolean;
+  final DateTime? _dateTime;
+  final DemoObject _demoObject;
+  final List<String> _list2;
+  final Set<String> _set2;
+  final Map<String, String> _map2;
+  final int _string2;
+  final bool _integer2;
+  final String _decimal2;
+  final int _num2;
+  final num _boolean2;
+  final DemoObject? _dateTime2;
+  final DemoObject2 _demoObject2;
+
+  List<String> get list => _list;
+
+  Set<String> get set1 => _set1;
+
+  Map<String, String> get map => _map;
+
+  String get string => _string;
+
+  int get integer => _integer;
+
+  double get decimal => _decimal;
+
+  num get num1 => _num1;
+
+  bool get boolean => _boolean;
+
+  DateTime? get dateTime => _dateTime;
+
+  DemoObject get demoObject => _demoObject;
+
+  List<String> get list2 => _list2;
+
+  Set<String> get set2 => _set2;
+
+  Map<String, String> get map2 => _map2;
+
+  int get string2 => _string2;
+
+  bool get integer2 => _integer2;
+
+  String get decimal2 => _decimal2;
+
+  int get num2 => _num2;
+
+  num get boolean2 => _boolean2;
+
+  DemoObject? get dateTime2 => _dateTime2;
+
+  DemoObject2 get demoObject2 => _demoObject2;
+}
+
+class DemoObject {
+  const DemoObject();
+}
+
+class DemoObject2 {
+  const DemoObject2();
 }

--- a/super_lint/example/pubspec.yaml
+++ b/super_lint/example/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  freezed_annotation: any
 
 dev_dependencies:
   custom_lint: 0.7.5

--- a/super_lint/example/pubspec.yaml
+++ b/super_lint/example/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  freezed_annotation: any
 
 dev_dependencies:
   custom_lint: 0.7.5

--- a/super_lint/lib/src/index.dart
+++ b/super_lint/lib/src/index.dart
@@ -41,6 +41,7 @@ export 'lints/incorrect_event_name.dart';
 export 'lints/incorrect_event_parameter_name.dart';
 export 'lints/incorrect_event_parameter_type.dart';
 export 'lints/incorrect_parent_class.dart';
+export 'lints/incorrect_freezed_default_value_type.dart';
 export 'lints/incorrect_screen_name_enum_value.dart';
 export 'lints/incorrect_screen_name_parameter_value.dart';
 export 'lints/incorrect_todo_comment.dart';

--- a/super_lint/lib/src/lints/incorrect_freezed_default_value_type.dart
+++ b/super_lint/lib/src/lints/incorrect_freezed_default_value_type.dart
@@ -1,0 +1,83 @@
+import '../index.dart';
+
+class IncorrectFreezedDefaultValueType extends OptionsLintRule<_IncorrectFreezedDefaultValueTypeOption> {
+  IncorrectFreezedDefaultValueType(
+    CustomLintConfigs configs,
+  ) : super(
+          RuleConfig(
+            name: lintName,
+            configs: configs,
+            paramsParser: _IncorrectFreezedDefaultValueTypeOption.fromMap,
+            problemMessage: (_) => 'The value used in @Default must match the field type.',
+          ),
+        );
+
+  static const String lintName = 'incorrect_freezed_default_value_type';
+
+  @override
+  Future<void> run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) async {
+    final rootPath = await resolver.rootPath;
+    final parameters = config.parameters;
+    if (parameters.shouldSkipAnalysis(
+      path: resolver.path,
+      rootPath: rootPath,
+    )) {
+      return;
+    }
+
+    final code = this.code.copyWith(
+          errorSeverity: parameters.severity ?? this.code.errorSeverity,
+        );
+
+    final resolvedUnit = await resolver.getResolvedUnitResult();
+    final typeSystem = resolvedUnit.typeSystem;
+
+    context.registry.addSimpleFormalParameter((node) {
+      final annotation = node.metadata.firstWhereOrNull((element) {
+        if (element.name.name != 'Default') return false;
+        final libraryUri = element.element?.librarySource.uri.toString();
+        return libraryUri?.contains('freezed_annotation') == true;
+      });
+
+      if (annotation == null) return;
+
+      final argList = annotation.arguments?.arguments;
+      final defaultArg = argList != null && argList.isNotEmpty ? argList.first : null;
+      if (defaultArg == null) return;
+
+      final defaultType = defaultArg.staticType;
+      final paramType = node.declaredElement?.type;
+      if (defaultType == null || paramType == null) return;
+
+      if (!typeSystem.isAssignableTo(defaultType, paramType)) {
+        reporter.atNode(annotation, code);
+      }
+    });
+  }
+}
+
+class _IncorrectFreezedDefaultValueTypeOption extends Excludable {
+  const _IncorrectFreezedDefaultValueTypeOption({
+    this.excludes = const [],
+    this.includes = const [],
+    this.severity,
+  });
+
+  final ErrorSeverity? severity;
+  @override
+  final List<String> excludes;
+  @override
+  final List<String> includes;
+
+  static _IncorrectFreezedDefaultValueTypeOption fromMap(Map<String, dynamic> map) {
+    return _IncorrectFreezedDefaultValueTypeOption(
+      excludes: safeCastToListString(map['excludes']),
+      includes: safeCastToListString(map['includes']),
+      severity: convertStringToErrorSeverity(map['severity']),
+    );
+  }
+}

--- a/super_lint/lib/src/lints/incorrect_freezed_default_value_type.dart
+++ b/super_lint/lib/src/lints/incorrect_freezed_default_value_type.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../index.dart';
 
 class IncorrectFreezedDefaultValueType extends OptionsLintRule<_IncorrectFreezedDefaultValueTypeOption> {
@@ -39,7 +41,7 @@ class IncorrectFreezedDefaultValueType extends OptionsLintRule<_IncorrectFreezed
     context.registry.addSimpleFormalParameter((node) {
       final annotation = node.metadata.firstWhereOrNull((element) {
         if (element.name.name != 'Default') return false;
-        final libraryUri = element.element?.librarySource.uri.toString();
+        final libraryUri = element.element2?.library2?.uri.toString();
         return libraryUri?.contains('freezed_annotation') == true;
       });
 
@@ -50,7 +52,7 @@ class IncorrectFreezedDefaultValueType extends OptionsLintRule<_IncorrectFreezed
       if (defaultArg == null) return;
 
       final defaultType = defaultArg.staticType;
-      final paramType = node.declaredElement?.type;
+      final paramType = node.declaredFragment?.element.type;
       if (defaultType == null || paramType == null) return;
 
       if (!typeSystem.isAssignableTo(defaultType, paramType)) {

--- a/super_lint/lib/super_lint.dart
+++ b/super_lint/lib/super_lint.dart
@@ -35,6 +35,7 @@ class _SuperLintPlugin extends PluginBase {
       UtilFunctionsMustBeStatic(configs),
       MissingExtensionMethodForEvents(configs),
       MissingCommonScrollbar(configs),
+      IncorrectFreezedDefaultValueType(configs),
       PreferSingleWidgetPerFile(configs),
     ];
   }


### PR DESCRIPTION
## Summary
- add lint `incorrect_freezed_default_value_type`
- document the new lint and update changelog
- add example usage and enable lint in example

## Testing
- `make fm` *(fails: `dart` not found)*
- `make sl` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6fdbaac883268df13f1636c8100f