### PR TITLE
Refactor lint options

### DIFF
--- a/super_lint/lib/src/base/common_lint_option.dart
+++ b/super_lint/lib/src/base/common_lint_option.dart
@@ -1,0 +1,19 @@
+import '../index.dart';
+
+/// Base option for lint rules containing common fields.
+abstract class CommonLintOption extends Excludable {
+  const CommonLintOption({
+    this.excludes = const [],
+    this.includes = const [],
+    this.severity,
+  });
+
+  @override
+  final List<String> excludes;
+
+  @override
+  final List<String> includes;
+
+  /// Severity override for the lint.
+  final ErrorSeverity? severity;
+}

--- a/super_lint/lib/src/index.dart
+++ b/super_lint/lib/src/index.dart
@@ -28,6 +28,7 @@ export 'package:yaml/yaml.dart';
 export 'base/excludable.dart';
 export 'base/options_fix.dart';
 export 'base/options_lint_rule.dart';
+export 'base/common_lint_option.dart';
 export 'base/rule_config.dart';
 export 'lints/avoid_dynamic.dart';
 export 'lints/avoid_hard_coded_colors.dart';

--- a/super_lint/lib/src/lints/avoid_dynamic.dart
+++ b/super_lint/lib/src/lints/avoid_dynamic.dart
@@ -5,14 +5,12 @@ class AvoidDynamic extends OptionsLintRule<_AvoidDynamicOption> {
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'avoid_dynamic',
             configs: configs,
             paramsParser: _AvoidDynamicOption.fromMap,
             problemMessage: (_) => 'Avoid using dynamic type.',
           ),
         );
-
-  static const String lintName = 'avoid_dynamic';
 
   @override
   Future<void> run(
@@ -20,18 +18,10 @@ class AvoidDynamic extends OptionsLintRule<_AvoidDynamicOption> {
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addNamedType((node) {
       if (node.type is! DynamicType) return;
@@ -57,18 +47,12 @@ class AvoidDynamic extends OptionsLintRule<_AvoidDynamicOption> {
   }
 }
 
-class _AvoidDynamicOption extends Excludable {
+class _AvoidDynamicOption extends CommonLintOption {
   const _AvoidDynamicOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _AvoidDynamicOption fromMap(Map<String, dynamic> map) {
     return _AvoidDynamicOption(

--- a/super_lint/lib/src/lints/avoid_hard_coded_colors.dart
+++ b/super_lint/lib/src/lints/avoid_hard_coded_colors.dart
@@ -5,13 +5,12 @@ class AvoidHardCodedColors extends OptionsLintRule<_AvoidHardCodedColorsOption> 
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-              name: lintName,
+              name: 'avoid_hard_coded_colors',
               configs: configs,
               paramsParser: _AvoidHardCodedColorsOption.fromMap,
               problemMessage: (_) =>
                   'Avoid hard-coding colors, except for Colors.transparent, such as Color(0xFFFFFF) and Colors.white.\nPlease use \'cl.xxx\' instead'),
         );
-  static const String lintName = 'avoid_hard_coded_colors';
 
   @override
   Future<void> run(
@@ -19,18 +18,10 @@ class AvoidHardCodedColors extends OptionsLintRule<_AvoidHardCodedColorsOption> 
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     unawaited(resolver
         .getResolvedUnitResult()
@@ -115,18 +106,12 @@ class AvoidHardCodedColors extends OptionsLintRule<_AvoidHardCodedColorsOption> 
   }
 }
 
-class _AvoidHardCodedColorsOption extends Excludable {
+class _AvoidHardCodedColorsOption extends CommonLintOption {
   const _AvoidHardCodedColorsOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _AvoidHardCodedColorsOption fromMap(Map<String, dynamic> map) {
     return _AvoidHardCodedColorsOption(

--- a/super_lint/lib/src/lints/avoid_hard_coded_strings.dart
+++ b/super_lint/lib/src/lints/avoid_hard_coded_strings.dart
@@ -5,7 +5,7 @@ class AvoidHardCodedStrings extends OptionsLintRule<_AvoidHardCodedStringsOption
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'avoid_hard_coded_strings',
             configs: configs,
             paramsParser: _AvoidHardCodedStringsOption.fromMap,
             problemMessage: (_) =>
@@ -13,7 +13,6 @@ class AvoidHardCodedStrings extends OptionsLintRule<_AvoidHardCodedStringsOption
           ),
         );
 
-  static const String lintName = 'avoid_hard_coded_strings';
 
   @override
   Future<void> run(
@@ -21,18 +20,10 @@ class AvoidHardCodedStrings extends OptionsLintRule<_AvoidHardCodedStringsOption
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addSimpleStringLiteral((node) {
       if (node.value.length < config.parameters.minimumLength) {
@@ -120,19 +111,13 @@ class _AvoidHardCodedStringsFix extends OptionsFix<_AvoidHardCodedStringsOption>
   }
 }
 
-class _AvoidHardCodedStringsOption extends Excludable {
+class _AvoidHardCodedStringsOption extends CommonLintOption {
   const _AvoidHardCodedStringsOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.minimumLength = _defaultMinimumLength,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   final int minimumLength;
 

--- a/super_lint/lib/src/lints/avoid_nested_conditions.dart
+++ b/super_lint/lib/src/lints/avoid_nested_conditions.dart
@@ -5,14 +5,13 @@ class AvoidNestedConditions extends OptionsLintRule<_AvoidNestedConditionsOption
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'avoid_nested_conditions',
             configs: configs,
             paramsParser: _AvoidNestedConditionsOption.fromMap,
             problemMessage: (_) => 'Avoid nested conditions; use early return instead.',
           ),
         );
 
-  static const String lintName = 'avoid_nested_conditions';
 
   final _nestingConditionalExpressionLevels = <ConditionalExpression, int>{};
   final _nestingIfStatementLevels = <IfStatement, int>{};
@@ -23,18 +22,10 @@ class AvoidNestedConditions extends OptionsLintRule<_AvoidNestedConditionsOption
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addConditionalExpression((node) {
       final parent = node.parent?.thisOrAncestorOfType<ConditionalExpression>();
@@ -64,19 +55,13 @@ class AvoidNestedConditions extends OptionsLintRule<_AvoidNestedConditionsOption
   }
 }
 
-class _AvoidNestedConditionsOption extends Excludable {
+class _AvoidNestedConditionsOption extends CommonLintOption {
   const _AvoidNestedConditionsOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.acceptableLevel = _defaultAcceptableLevel,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
   final int acceptableLevel;
 
   static _AvoidNestedConditionsOption fromMap(Map<String, dynamic> map) {

--- a/super_lint/lib/src/lints/avoid_unnecessary_async_function.dart
+++ b/super_lint/lib/src/lints/avoid_unnecessary_async_function.dart
@@ -5,14 +5,12 @@ class AvoidUnnecessaryAsyncFunction extends OptionsLintRule<_AvoidUnnecessaryAsy
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-              name: lintName,
+              name: 'avoid_unnecessary_async_function',
               configs: configs,
               paramsParser: _AvoidUnnecessaryAsyncFunctionOption.fromMap,
               problemMessage: (_) =>
                   'This async function is unnecessary. Please remove \'async\' keyword'),
         );
-
-  static const String lintName = 'avoid_unnecessary_async_function';
 
   @override
   Future<void> run(
@@ -20,18 +18,10 @@ class AvoidUnnecessaryAsyncFunction extends OptionsLintRule<_AvoidUnnecessaryAsy
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     unawaited(resolver.getResolvedUnitResult().then(
           (value) => value.unit.visitChildren(
@@ -155,18 +145,12 @@ class _RemoveUnnecessaryAsyncKeyWord extends OptionsFix<_AvoidUnnecessaryAsyncFu
   }
 }
 
-class _AvoidUnnecessaryAsyncFunctionOption extends Excludable {
+class _AvoidUnnecessaryAsyncFunctionOption extends CommonLintOption {
   const _AvoidUnnecessaryAsyncFunctionOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _AvoidUnnecessaryAsyncFunctionOption fromMap(Map<String, dynamic> map) {
     return _AvoidUnnecessaryAsyncFunctionOption(

--- a/super_lint/lib/src/lints/avoid_using_if_else_with_enums.dart
+++ b/super_lint/lib/src/lints/avoid_using_if_else_with_enums.dart
@@ -5,14 +5,13 @@ class AvoidUsingIfElseWithEnums extends OptionsLintRule<_AvoidUsingIfElseWithEnu
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'avoid_using_if_else_with_enums',
             configs: configs,
             paramsParser: _AvoidUsingIfElseWithEnumsOption.fromMap,
             problemMessage: (_) => 'Avoid using if-else with enums. Use switch-case instead.',
           ),
         );
 
-  static const String lintName = 'avoid_using_if_else_with_enums';
 
   @override
   Future<void> run(
@@ -20,18 +19,10 @@ class AvoidUsingIfElseWithEnums extends OptionsLintRule<_AvoidUsingIfElseWithEnu
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addIfStatement((node) {
       if (node.expression is! BinaryExpression) {
@@ -82,19 +73,13 @@ class AvoidUsingIfElseWithEnums extends OptionsLintRule<_AvoidUsingIfElseWithEnu
   }
 }
 
-class _AvoidUsingIfElseWithEnumsOption extends Excludable {
+class _AvoidUsingIfElseWithEnumsOption extends CommonLintOption {
   const _AvoidUsingIfElseWithEnumsOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.includeConditionalExpression = true,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
   final bool includeConditionalExpression;
 
   static _AvoidUsingIfElseWithEnumsOption fromMap(Map<String, dynamic> map) {

--- a/super_lint/lib/src/lints/avoid_using_text_style_constructor_directly.dart
+++ b/super_lint/lib/src/lints/avoid_using_text_style_constructor_directly.dart
@@ -6,7 +6,7 @@ class AvoidUsingTextStyleConstructorDirectly
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'avoid_using_text_style_constructor_directly',
             configs: configs,
             paramsParser: _AvoidUsingTextStyleConstructorOption.fromMap,
             problemMessage: (_) =>
@@ -14,7 +14,6 @@ class AvoidUsingTextStyleConstructorDirectly
           ),
         );
 
-  static const String lintName = 'avoid_using_text_style_constructor_directly';
 
   @override
   Future<void> run(
@@ -22,18 +21,10 @@ class AvoidUsingTextStyleConstructorDirectly
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addInstanceCreationExpression((node) {
       if (node.constructorName.type.type.toString() == 'TextStyle') {
@@ -81,18 +72,12 @@ class _ReplaceTextStyleWithStyleFunction extends OptionsFix<_AvoidUsingTextStyle
   }
 }
 
-class _AvoidUsingTextStyleConstructorOption extends Excludable {
+class _AvoidUsingTextStyleConstructorOption extends CommonLintOption {
   const _AvoidUsingTextStyleConstructorOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _AvoidUsingTextStyleConstructorOption fromMap(Map<String, dynamic> map) {
     return _AvoidUsingTextStyleConstructorOption(

--- a/super_lint/lib/src/lints/avoid_using_unsafe_cast.dart
+++ b/super_lint/lib/src/lints/avoid_using_unsafe_cast.dart
@@ -5,14 +5,13 @@ class AvoidUsingUnsafeCast extends OptionsLintRule<_AvoidUsingUnsafeCastOption> 
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'avoid_using_unsafe_cast',
             configs: configs,
             paramsParser: _AvoidUsingUnsafeCastOption.fromMap,
             problemMessage: (_) => 'Avoid using unsafe cast. Use \'safeCast\' function instead.',
           ),
         );
 
-  static const String lintName = 'avoid_using_unsafe_cast';
 
   @override
   Future<void> run(
@@ -20,18 +19,10 @@ class AvoidUsingUnsafeCast extends OptionsLintRule<_AvoidUsingUnsafeCastOption> 
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addAsExpression((node) {
       reporter.atToken(
@@ -105,18 +96,12 @@ class ReplaceWithSafeCast extends OptionsFix<_AvoidUsingUnsafeCastOption> {
   }
 }
 
-class _AvoidUsingUnsafeCastOption extends Excludable {
+class _AvoidUsingUnsafeCastOption extends CommonLintOption {
   const _AvoidUsingUnsafeCastOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _AvoidUsingUnsafeCastOption fromMap(Map<String, dynamic> map) {
     return _AvoidUsingUnsafeCastOption(

--- a/super_lint/lib/src/lints/incorrect_event_name.dart
+++ b/super_lint/lib/src/lints/incorrect_event_name.dart
@@ -7,14 +7,13 @@ class IncorrectEventName extends OptionsLintRule<_IncorrectEventNameOption> {
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'incorrect_event_name',
             configs: configs,
             paramsParser: _IncorrectEventNameOption.fromMap,
             problemMessage: (options) => 'Events in `$_className` must use snake_case naming.',
           ),
         );
 
-  static const String lintName = 'incorrect_event_name';
 
   @override
   Future<void> run(
@@ -22,19 +21,10 @@ class IncorrectEventName extends OptionsLintRule<_IncorrectEventNameOption> {
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addClassDeclaration((node) {
       final className = node.name.lexeme;
@@ -59,18 +49,12 @@ class IncorrectEventName extends OptionsLintRule<_IncorrectEventNameOption> {
   }
 }
 
-class _IncorrectEventNameOption extends Excludable {
+class _IncorrectEventNameOption extends CommonLintOption {
   const _IncorrectEventNameOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _IncorrectEventNameOption fromMap(Map<String, dynamic> map) {
     return _IncorrectEventNameOption(

--- a/super_lint/lib/src/lints/incorrect_event_parameter_name.dart
+++ b/super_lint/lib/src/lints/incorrect_event_parameter_name.dart
@@ -7,14 +7,13 @@ class IncorrectEventParameterName extends OptionsLintRule<_IncorrectEventParamet
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'incorrect_event_parameter_name',
             configs: configs,
             paramsParser: _IncorrectEventParameterNameOption.fromMap,
             problemMessage: (options) => 'Parameters in `$_className` must use snake_case naming.',
           ),
         );
 
-  static const String lintName = 'incorrect_event_parameter_name';
 
   @override
   Future<void> run(
@@ -22,19 +21,10 @@ class IncorrectEventParameterName extends OptionsLintRule<_IncorrectEventParamet
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addClassDeclaration((node) {
       final className = node.name.lexeme;
@@ -59,18 +49,12 @@ class IncorrectEventParameterName extends OptionsLintRule<_IncorrectEventParamet
   }
 }
 
-class _IncorrectEventParameterNameOption extends Excludable {
+class _IncorrectEventParameterNameOption extends CommonLintOption {
   const _IncorrectEventParameterNameOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _IncorrectEventParameterNameOption fromMap(Map<String, dynamic> map) {
     return _IncorrectEventParameterNameOption(

--- a/super_lint/lib/src/lints/incorrect_event_parameter_type.dart
+++ b/super_lint/lib/src/lints/incorrect_event_parameter_type.dart
@@ -6,14 +6,13 @@ class IncorrectEventParameterType extends OptionsLintRule<_IncorrectEventParamet
   IncorrectEventParameterType(CustomLintConfigs configs)
       : super(
           RuleConfig(
-            name: lintName,
+            name: 'incorrect_event_parameter_type',
             configs: configs,
             paramsParser: _IncorrectEventParameterTypeOption.fromMap,
             problemMessage: (params) => 'Parameters must only allow String, int or double values.',
           ),
         );
 
-  static const String lintName = 'incorrect_event_parameter_type';
 
   @override
   Future<void> run(
@@ -21,19 +20,10 @@ class IncorrectEventParameterType extends OptionsLintRule<_IncorrectEventParamet
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addClassDeclaration((classNode) {
       final isAnalyticParameterSubclass =
@@ -68,18 +58,12 @@ class IncorrectEventParameterType extends OptionsLintRule<_IncorrectEventParamet
   }
 }
 
-class _IncorrectEventParameterTypeOption extends Excludable {
+class _IncorrectEventParameterTypeOption extends CommonLintOption {
   const _IncorrectEventParameterTypeOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _IncorrectEventParameterTypeOption fromMap(Map<String, dynamic> map) {
     return _IncorrectEventParameterTypeOption(

--- a/super_lint/lib/src/lints/incorrect_freezed_default_value_type.dart
+++ b/super_lint/lib/src/lints/incorrect_freezed_default_value_type.dart
@@ -7,14 +7,13 @@ class IncorrectFreezedDefaultValueType extends OptionsLintRule<_IncorrectFreezed
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'incorrect_freezed_default_value_type',
             configs: configs,
             paramsParser: _IncorrectFreezedDefaultValueTypeOption.fromMap,
             problemMessage: (_) => 'The value used in @Default must match the field type.',
           ),
         );
 
-  static const String lintName = 'incorrect_freezed_default_value_type';
 
   @override
   Future<void> run(
@@ -22,18 +21,10 @@ class IncorrectFreezedDefaultValueType extends OptionsLintRule<_IncorrectFreezed
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     final resolvedUnit = await resolver.getResolvedUnitResult();
     final typeSystem = resolvedUnit.typeSystem;
@@ -62,18 +53,12 @@ class IncorrectFreezedDefaultValueType extends OptionsLintRule<_IncorrectFreezed
   }
 }
 
-class _IncorrectFreezedDefaultValueTypeOption extends Excludable {
+class _IncorrectFreezedDefaultValueTypeOption extends CommonLintOption {
   const _IncorrectFreezedDefaultValueTypeOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _IncorrectFreezedDefaultValueTypeOption fromMap(Map<String, dynamic> map) {
     return _IncorrectFreezedDefaultValueTypeOption(

--- a/super_lint/lib/src/lints/incorrect_parent_class.dart
+++ b/super_lint/lib/src/lints/incorrect_parent_class.dart
@@ -5,7 +5,7 @@ class IncorrectParentClass extends OptionsLintRule<_IncorrectParentClassOption> 
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'incorrect_parent_class',
             configs: configs,
             paramsParser: _IncorrectParentClassOption.fromMap,
             problemMessage: (options) =>
@@ -13,7 +13,6 @@ class IncorrectParentClass extends OptionsLintRule<_IncorrectParentClassOption> 
           ),
         );
 
-  static const String lintName = 'incorrect_parent_class';
 
   @override
   Future<void> run(
@@ -21,18 +20,10 @@ class IncorrectParentClass extends OptionsLintRule<_IncorrectParentClassOption> 
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addClassDeclaration((node) {
       final parent = node.extendsClause?.superclass;
@@ -51,20 +42,14 @@ class IncorrectParentClass extends OptionsLintRule<_IncorrectParentClassOption> 
   }
 }
 
-class _IncorrectParentClassOption extends Excludable {
+class _IncorrectParentClassOption extends CommonLintOption {
   const _IncorrectParentClassOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.classPostFixes = _defaultClassPostFixes,
     this.parentClassPreFixes = _defaultParentClassPreFixes,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   final List<String> classPostFixes;
   final List<String> parentClassPreFixes;

--- a/super_lint/lib/src/lints/incorrect_screen_name_enum_value.dart
+++ b/super_lint/lib/src/lints/incorrect_screen_name_enum_value.dart
@@ -4,7 +4,7 @@ class IncorrectScreenNameEnumValue extends OptionsLintRule<_IncorrectScreenNameE
   IncorrectScreenNameEnumValue(CustomLintConfigs configs)
       : super(
           RuleConfig(
-            name: lintName,
+            name: 'incorrect_screen_name_enum_value',
             configs: configs,
             paramsParser: _IncorrectScreenNameEnumValueOption.fromMap,
             problemMessage: (params) =>
@@ -12,7 +12,6 @@ class IncorrectScreenNameEnumValue extends OptionsLintRule<_IncorrectScreenNameE
           ),
         );
 
-  static const String lintName = 'incorrect_screen_name_enum_value';
 
   @override
   Future<void> run(
@@ -70,18 +69,12 @@ class IncorrectScreenNameEnumValue extends OptionsLintRule<_IncorrectScreenNameE
   }
 }
 
-class _IncorrectScreenNameEnumValueOption extends Excludable {
+class _IncorrectScreenNameEnumValueOption extends CommonLintOption {
   const _IncorrectScreenNameEnumValueOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _IncorrectScreenNameEnumValueOption fromMap(Map<String, dynamic> map) {
     return _IncorrectScreenNameEnumValueOption(

--- a/super_lint/lib/src/lints/incorrect_screen_name_parameter_value.dart
+++ b/super_lint/lib/src/lints/incorrect_screen_name_parameter_value.dart
@@ -5,14 +5,13 @@ class IncorrectScreenNameParameterValue
   IncorrectScreenNameParameterValue(CustomLintConfigs configs)
       : super(
           RuleConfig(
-            name: lintName,
+            name: 'incorrect_screen_name_parameter_value',
             configs: configs,
             paramsParser: _IncorrectScreenNameParameterValueOption.fromMap,
             problemMessage: (params) => 'The screenName does not match the file name.',
           ),
         );
 
-  static const String lintName = 'incorrect_screen_name_parameter_value';
 
   @override
   Future<void> run(
@@ -20,19 +19,10 @@ class IncorrectScreenNameParameterValue
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     final fileName = resolver.path.split('/').last.split('.').first;
     final expectedScreenName = fileName.toCamelCase();
@@ -94,18 +84,12 @@ class _FixIncorrectScreenName extends OptionsFix<_IncorrectScreenNameParameterVa
   }
 }
 
-class _IncorrectScreenNameParameterValueOption extends Excludable {
+class _IncorrectScreenNameParameterValueOption extends CommonLintOption {
   const _IncorrectScreenNameParameterValueOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _IncorrectScreenNameParameterValueOption fromMap(Map<String, dynamic> map) {
     return _IncorrectScreenNameParameterValueOption(

--- a/super_lint/lib/src/lints/incorrect_todo_comment.dart
+++ b/super_lint/lib/src/lints/incorrect_todo_comment.dart
@@ -5,7 +5,7 @@ class IncorrectTodoComment extends OptionsLintRule<_IncorrectTodoCommentOption> 
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-              name: lintName,
+              name: 'incorrect_todo_comment',
               configs: configs,
               paramsParser: _IncorrectTodoCommentOption.fromMap,
               problemMessage: (_) =>
@@ -13,7 +13,6 @@ class IncorrectTodoComment extends OptionsLintRule<_IncorrectTodoCommentOption> 
                   'Example: // TODO(username): some description text #123.'),
         );
 
-  static const String lintName = 'incorrect_todo_comment';
 
   @override
   Future<void> run(
@@ -21,18 +20,10 @@ class IncorrectTodoComment extends OptionsLintRule<_IncorrectTodoCommentOption> 
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     resolver.getLineContents((codeLine) {
       if (codeLine.isEndOfLineComment) {
@@ -49,18 +40,12 @@ class IncorrectTodoComment extends OptionsLintRule<_IncorrectTodoCommentOption> 
   }
 }
 
-class _IncorrectTodoCommentOption extends Excludable {
+class _IncorrectTodoCommentOption extends CommonLintOption {
   const _IncorrectTodoCommentOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _IncorrectTodoCommentOption fromMap(Map<String, dynamic> map) {
     return _IncorrectTodoCommentOption(

--- a/super_lint/lib/src/lints/missing_common_scrollbar.dart
+++ b/super_lint/lib/src/lints/missing_common_scrollbar.dart
@@ -4,28 +4,19 @@ class MissingCommonScrollbar extends OptionsLintRule<_MissingCommonScrollbarOpti
   MissingCommonScrollbar(
     CustomLintConfigs configs,
   ) : super(RuleConfig(
-            name: lintName,
+            name: 'missing_common_scrollbar',
             configs: configs,
             paramsParser: _MissingCommonScrollbarOption.fromMap,
             problemMessage: (_) =>
                 'Scrollable widgets in a Page class must be wrapped with CommonScrollbar.'));
 
-  static const String lintName = 'missing_common_scrollbar';
 
   @override
   void run(CustomLintResolver resolver, ErrorReporter reporter, CustomLintContext context) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addInstanceCreationExpression((node) {
       final widgetName = node.staticType?.getDisplayString();
@@ -77,20 +68,14 @@ class MissingCommonScrollbar extends OptionsLintRule<_MissingCommonScrollbarOpti
   }
 }
 
-class _MissingCommonScrollbarOption extends Excludable {
+class _MissingCommonScrollbarOption extends CommonLintOption {
   const _MissingCommonScrollbarOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.commonScrollbarWidgetName = _defaultCommonScrollbarWidgetName,
     this.scrollableWidgetNames = _defaultScrollableWidgetNames,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
   final String commonScrollbarWidgetName;
   final List<String> scrollableWidgetNames;
 

--- a/super_lint/lib/src/lints/missing_expanded_or_flexible.dart
+++ b/super_lint/lib/src/lints/missing_expanded_or_flexible.dart
@@ -7,7 +7,7 @@ class MissingExpandedOrFlexible extends OptionsLintRule<_MissingExpandedOrFlexib
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'missing_expanded_or_flexible',
             configs: configs,
             paramsParser: _MissingExpandedOrFlexibleOption.fromMap,
             problemMessage: (options) =>
@@ -15,7 +15,6 @@ class MissingExpandedOrFlexible extends OptionsLintRule<_MissingExpandedOrFlexib
           ),
         );
 
-  static const String lintName = 'missing_expanded_or_flexible';
 
   @override
   Future<void> run(
@@ -23,18 +22,10 @@ class MissingExpandedOrFlexible extends OptionsLintRule<_MissingExpandedOrFlexib
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addInstanceCreationExpression((node) {
       final widget = node.constructorName.type.toString();
@@ -65,18 +56,12 @@ class MissingExpandedOrFlexible extends OptionsLintRule<_MissingExpandedOrFlexib
   }
 }
 
-class _MissingExpandedOrFlexibleOption extends Excludable {
+class _MissingExpandedOrFlexibleOption extends CommonLintOption {
   const _MissingExpandedOrFlexibleOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _MissingExpandedOrFlexibleOption fromMap(Map<String, dynamic> map) {
     return _MissingExpandedOrFlexibleOption(

--- a/super_lint/lib/src/lints/missing_extension_method_for_events.dart
+++ b/super_lint/lib/src/lints/missing_extension_method_for_events.dart
@@ -8,14 +8,13 @@ class MissingExtensionMethodForEvents
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'missing_extension_method_for_events',
             configs: configs,
             paramsParser: _MissingExtensionMethodForEventsOption.fromMap,
             problemMessage: (params) => 'Missing extension method for events for this class',
           ),
         );
 
-  static const String lintName = 'missing_extension_method_for_events';
 
   @override
   Future<void> run(
@@ -23,19 +22,10 @@ class MissingExtensionMethodForEvents
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addCompilationUnit((unit) {
       final extensions = <ExtensionDeclaration>[];
@@ -174,18 +164,12 @@ extension $expectedExtensionName on $_extendedType {}
   }
 }
 
-class _MissingExtensionMethodForEventsOption extends Excludable {
+class _MissingExtensionMethodForEventsOption extends CommonLintOption {
   const _MissingExtensionMethodForEventsOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _MissingExtensionMethodForEventsOption fromMap(Map<String, dynamic> map) {
     return _MissingExtensionMethodForEventsOption(

--- a/super_lint/lib/src/lints/missing_log_in_catch_block.dart
+++ b/super_lint/lib/src/lints/missing_log_in_catch_block.dart
@@ -5,7 +5,7 @@ class MissingLogInCatchBlock extends OptionsLintRule<_MissingLogInCatchBlockOpti
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'missing_log_in_catch_block',
             configs: configs,
             paramsParser: _MissingLogInCatchBlockOption.fromMap,
             problemMessage: (_) =>
@@ -13,7 +13,6 @@ class MissingLogInCatchBlock extends OptionsLintRule<_MissingLogInCatchBlockOpti
           ),
         );
 
-  static const String lintName = 'missing_log_in_catch_block';
 
   @override
   Future<void> run(
@@ -21,18 +20,10 @@ class MissingLogInCatchBlock extends OptionsLintRule<_MissingLogInCatchBlockOpti
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addCatchClause((node) {
       final methodInvocations = node.body.childMethodInvocations;
@@ -49,20 +40,14 @@ class MissingLogInCatchBlock extends OptionsLintRule<_MissingLogInCatchBlockOpti
   }
 }
 
-class _MissingLogInCatchBlockOption extends Excludable {
+class _MissingLogInCatchBlockOption extends CommonLintOption {
   _MissingLogInCatchBlockOption({
-    this.excludes = const [],
-    this.includes = const [],
+    super.excludes,
+    super.includes,
     this.methods = _defaultMethods,
     this.className = _defaultClassName,
-    this.severity,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
   final List<String> methods;
   final String className;
 

--- a/super_lint/lib/src/lints/missing_run_catching.dart
+++ b/super_lint/lib/src/lints/missing_run_catching.dart
@@ -10,7 +10,7 @@ class MissingRunCatching extends OptionsLintRule<_MissingRunCatchingOption> {
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'missing_run_catching',
             configs: configs,
             paramsParser: _MissingRunCatchingOption.fromMap,
             problemMessage: (_) =>
@@ -18,7 +18,6 @@ class MissingRunCatching extends OptionsLintRule<_MissingRunCatchingOption> {
           ),
         );
 
-  static const String lintName = 'missing_run_catching';
 
   @override
   Future<void> run(
@@ -26,18 +25,10 @@ class MissingRunCatching extends OptionsLintRule<_MissingRunCatchingOption> {
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addMethodInvocation((node) {
       if (_addPrivateCase(parameters.startsWithPatterns).any(
@@ -98,20 +89,14 @@ class MissingRunCatching extends OptionsLintRule<_MissingRunCatchingOption> {
   }
 }
 
-class _MissingRunCatchingOption extends Excludable {
+class _MissingRunCatchingOption extends CommonLintOption {
   const _MissingRunCatchingOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.startsWithPatterns = _defaultStartsWithPatterns,
     this.startsWithPatternsExcludes = _defaultStartsWithPatternsExcludes,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
   final List<String> startsWithPatterns;
   final List<String> startsWithPatternsExcludes;
 

--- a/super_lint/lib/src/lints/prefer_async_await.dart
+++ b/super_lint/lib/src/lints/prefer_async_await.dart
@@ -5,14 +5,13 @@ class PreferAsyncAwait extends OptionsLintRule<_PreferAsyncAwaitOption> {
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'prefer_async_await',
             configs: configs,
             paramsParser: _PreferAsyncAwaitOption.fromMap,
             problemMessage: (_) => 'Prefer using async/await syntax instead of .then invocations',
           ),
         );
 
-  static const String lintName = 'prefer_async_await';
 
   @override
   Future<void> run(
@@ -20,18 +19,10 @@ class PreferAsyncAwait extends OptionsLintRule<_PreferAsyncAwaitOption> {
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addMethodInvocation((node) {
       final target = node.realTarget;
@@ -48,18 +39,12 @@ class PreferAsyncAwait extends OptionsLintRule<_PreferAsyncAwaitOption> {
   }
 }
 
-class _PreferAsyncAwaitOption extends Excludable {
+class _PreferAsyncAwaitOption extends CommonLintOption {
   const _PreferAsyncAwaitOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _PreferAsyncAwaitOption fromMap(Map<String, dynamic> map) {
     return _PreferAsyncAwaitOption(

--- a/super_lint/lib/src/lints/prefer_common_widgets.dart
+++ b/super_lint/lib/src/lints/prefer_common_widgets.dart
@@ -7,7 +7,7 @@ class PreferCommonWidgets extends OptionsLintRule<_PreferCommonWidgetsOption> {
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'prefer_common_widgets',
             configs: configs,
             paramsParser: _PreferCommonWidgetsOption.fromMap,
             problemMessage: (_) =>
@@ -15,7 +15,6 @@ class PreferCommonWidgets extends OptionsLintRule<_PreferCommonWidgetsOption> {
           ),
         );
 
-  static const String lintName = 'prefer_common_widgets';
 
   @override
   Future<void> run(
@@ -23,18 +22,10 @@ class PreferCommonWidgets extends OptionsLintRule<_PreferCommonWidgetsOption> {
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addInstanceCreationExpression((node) {
       final bannedWidget = parameters.bannedWidgets.firstWhereOrNull((element) {
@@ -96,19 +87,13 @@ class _ReplaceWithCommonWidget extends OptionsFix<_PreferCommonWidgetsOption> {
   }
 }
 
-class _PreferCommonWidgetsOption extends Excludable {
+class _PreferCommonWidgetsOption extends CommonLintOption {
   const _PreferCommonWidgetsOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.bannedWidgets = _defaultBannedWidgets,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   final List<Map<String, String>> bannedWidgets;
 

--- a/super_lint/lib/src/lints/prefer_importing_index_file.dart
+++ b/super_lint/lib/src/lints/prefer_importing_index_file.dart
@@ -5,7 +5,7 @@ class PreferImportingIndexFile extends OptionsLintRule<_PreferImportingIndexFile
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'prefer_importing_index_file',
             configs: configs,
             paramsParser: _PreferImportingIndexFileOption.fromMap,
             problemMessage: (options) =>
@@ -13,7 +13,6 @@ class PreferImportingIndexFile extends OptionsLintRule<_PreferImportingIndexFile
           ),
         );
 
-  static const String lintName = 'prefer_importing_index_file';
 
   @override
   Future<void> run(
@@ -21,18 +20,10 @@ class PreferImportingIndexFile extends OptionsLintRule<_PreferImportingIndexFile
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addImportDirective((node) {
       final importUri = node.uri.stringValue;
@@ -46,20 +37,14 @@ class PreferImportingIndexFile extends OptionsLintRule<_PreferImportingIndexFile
   }
 }
 
-class _PreferImportingIndexFileOption extends Excludable {
+class _PreferImportingIndexFileOption extends CommonLintOption {
   const _PreferImportingIndexFileOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.classPostFixes = _defaultClassPostFixes,
     this.parentClassPreFixes = _defaultParentClassPreFixes,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   final List<String> classPostFixes;
   final List<String> parentClassPreFixes;

--- a/super_lint/lib/src/lints/prefer_is_empty_string.dart
+++ b/super_lint/lib/src/lints/prefer_is_empty_string.dart
@@ -5,7 +5,7 @@ class PreferIsEmptyString extends OptionsLintRule<_PreferIsEmptyStringOption> {
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'prefer_is_empty_string',
             configs: configs,
             paramsParser: _PreferIsEmptyStringOption.fromMap,
             problemMessage: (_) =>
@@ -13,7 +13,6 @@ class PreferIsEmptyString extends OptionsLintRule<_PreferIsEmptyStringOption> {
           ),
         );
 
-  static const String lintName = 'prefer_is_empty_string';
 
   @override
   Future<void> run(
@@ -21,18 +20,10 @@ class PreferIsEmptyString extends OptionsLintRule<_PreferIsEmptyStringOption> {
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addBinaryExpression((node) {
       if (node.operator.type == TokenType.EQ_EQ &&
@@ -84,18 +75,12 @@ class _ReplaceWithIsEmpty extends OptionsFix<_PreferIsEmptyStringOption> {
   }
 }
 
-class _PreferIsEmptyStringOption extends Excludable {
+class _PreferIsEmptyStringOption extends CommonLintOption {
   const _PreferIsEmptyStringOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _PreferIsEmptyStringOption fromMap(Map<String, dynamic> map) {
     return _PreferIsEmptyStringOption(

--- a/super_lint/lib/src/lints/prefer_is_not_empty_string.dart
+++ b/super_lint/lib/src/lints/prefer_is_not_empty_string.dart
@@ -5,7 +5,7 @@ class PreferIsNotEmptyString extends OptionsLintRule<_PreferIsNotEmptyStringOpti
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'prefer_is_not_empty_string',
             configs: configs,
             paramsParser: _PreferIsNotEmptyStringOption.fromMap,
             problemMessage: (_) =>
@@ -13,25 +13,16 @@ class PreferIsNotEmptyString extends OptionsLintRule<_PreferIsNotEmptyStringOpti
           ),
         );
 
-  static const String lintName = 'prefer_is_not_empty_string';
   @override
   Future<void> run(
     CustomLintResolver resolver,
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addBinaryExpression((node) {
       if (node.operator.type == TokenType.BANG_EQ &&
@@ -83,18 +74,12 @@ class _ReplaceWithIsNotEmpty extends OptionsFix<_PreferIsNotEmptyStringOption> {
   }
 }
 
-class _PreferIsNotEmptyStringOption extends Excludable {
+class _PreferIsNotEmptyStringOption extends CommonLintOption {
   const _PreferIsNotEmptyStringOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _PreferIsNotEmptyStringOption fromMap(Map<String, dynamic> map) {
     return _PreferIsNotEmptyStringOption(

--- a/super_lint/lib/src/lints/prefer_lower_case_test_description.dart
+++ b/super_lint/lib/src/lints/prefer_lower_case_test_description.dart
@@ -11,14 +11,13 @@ class PreferLowerCaseTestDescription
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-              name: lintName,
+              name: 'prefer_lower_case_test_description',
               configs: configs,
               paramsParser: _PreferLowerCaseTestDescriptionOption.fromMap,
               problemMessage: (_) =>
                   'Lower case the first character when writing tests descriptions.'),
         );
 
-  static const String lintName = 'prefer_lower_case_test_description';
 
   @override
   Future<void> run(
@@ -26,18 +25,10 @@ class PreferLowerCaseTestDescription
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addMethodInvocation((node) {
       final testMethod = parameters.testMethods.firstWhereOrNull((element) {
@@ -122,19 +113,13 @@ class _ChangeToLowerCase extends OptionsFix<_PreferLowerCaseTestDescriptionOptio
   }
 }
 
-class _PreferLowerCaseTestDescriptionOption extends Excludable {
+class _PreferLowerCaseTestDescriptionOption extends CommonLintOption {
   const _PreferLowerCaseTestDescriptionOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.testMethods = _defaultTestMethods,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   final List<Map<String, String>> testMethods;
 

--- a/super_lint/lib/src/lints/prefer_single_widget_per_file.dart
+++ b/super_lint/lib/src/lints/prefer_single_widget_per_file.dart
@@ -7,29 +7,20 @@ class PreferSingleWidgetPerFile extends OptionsLintRule<_PreferSingleWidgetPerFi
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'prefer_single_widget_per_file',
             configs: configs,
             paramsParser: _PreferSingleWidgetPerFileOption.fromMap,
             problemMessage: (_) => 'Prefer single public widget per file',
           ),
         );
 
-  static const String lintName = 'prefer_single_widget_per_file';
 
   @override
   void run(CustomLintResolver resolver, ErrorReporter reporter, CustomLintContext context) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     final unit = (await resolver.getResolvedUnitResult()).unit;
     final fileName = p.basenameWithoutExtension(resolver.path);
@@ -60,19 +51,12 @@ class PreferSingleWidgetPerFile extends OptionsLintRule<_PreferSingleWidgetPerFi
   }
 }
 
-class _PreferSingleWidgetPerFileOption extends Excludable {
+class _PreferSingleWidgetPerFileOption extends CommonLintOption {
   const _PreferSingleWidgetPerFileOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
   });
-
-  final ErrorSeverity? severity;
-
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
 
   static _PreferSingleWidgetPerFileOption fromMap(Map<String, dynamic> map) {
     return _PreferSingleWidgetPerFileOption(

--- a/super_lint/lib/src/lints/test_folder_must_mirror_lib_folder.dart
+++ b/super_lint/lib/src/lints/test_folder_must_mirror_lib_folder.dart
@@ -7,7 +7,7 @@ class TestFolderMustMirrorLibFolder extends OptionsLintRule<_TestFolderMustMirro
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'test_folder_must_mirror_lib_folder',
             configs: configs,
             paramsParser: _TestFolderMustMirrorLibFolderOption.fromMap,
             problemMessage: (_) =>
@@ -15,7 +15,6 @@ class TestFolderMustMirrorLibFolder extends OptionsLintRule<_TestFolderMustMirro
           ),
         );
 
-  static const String lintName = 'test_folder_must_mirror_lib_folder';
   static const _testFileSuffix = '_test';
 
   @override
@@ -24,18 +23,10 @@ class TestFolderMustMirrorLibFolder extends OptionsLintRule<_TestFolderMustMirro
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     final relatedPath = relativePath(resolver.path, rootPath);
 
@@ -71,20 +62,14 @@ class TestFolderMustMirrorLibFolder extends OptionsLintRule<_TestFolderMustMirro
   }
 }
 
-class _TestFolderMustMirrorLibFolderOption extends Excludable {
+class _TestFolderMustMirrorLibFolderOption extends CommonLintOption {
   const _TestFolderMustMirrorLibFolderOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.libFolderPath = _defaultLibFolderPath,
     this.testFolderPaths = _defaultTestFolderPaths,
   });
-
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
   final String libFolderPath;
   final List<String> testFolderPaths;
 

--- a/super_lint/lib/src/lints/util_functions_must_be_static.dart
+++ b/super_lint/lib/src/lints/util_functions_must_be_static.dart
@@ -5,14 +5,13 @@ class UtilFunctionsMustBeStatic extends OptionsLintRule<_UtilFunctionsMustBeStat
     CustomLintConfigs configs,
   ) : super(
           RuleConfig(
-            name: lintName,
+            name: 'util_functions_must_be_static',
             configs: configs,
             paramsParser: _UtilFunctionsMustBeStaticOption.fromMap,
             problemMessage: (_) => 'Util functions must be declared as static functions.',
           ),
         );
 
-  static const String lintName = 'util_functions_must_be_static';
 
   @override
   Future<void> run(
@@ -20,18 +19,10 @@ class UtilFunctionsMustBeStatic extends OptionsLintRule<_UtilFunctionsMustBeStat
     ErrorReporter reporter,
     CustomLintContext context,
   ) async {
-    final rootPath = await resolver.rootPath;
-    final parameters = config.parameters;
-    if (parameters.shouldSkipAnalysis(
-      path: resolver.path,
-      rootPath: rootPath,
-    )) {
-      return;
-    }
-
-    final code = this.code.copyWith(
-          errorSeverity: parameters.severity ?? this.code.errorSeverity,
-        );
+    final runCtx = await prepareRun(resolver);
+    if (runCtx == null) return;
+    final code = runCtx.code;
+    final parameters = runCtx.parameters;
 
     context.registry.addFunctionDeclaration((node) {
       if (node.parent is CompilationUnit && !node.isPrivate && !node.isAnnotation) {
@@ -84,19 +75,14 @@ class ConvertToStaticFunction extends OptionsFix<_UtilFunctionsMustBeStaticOptio
   }
 }
 
-class _UtilFunctionsMustBeStaticOption extends Excludable {
+class _UtilFunctionsMustBeStaticOption extends CommonLintOption {
   const _UtilFunctionsMustBeStaticOption({
-    this.excludes = const [],
-    this.includes = const [],
-    this.severity,
+    super.excludes,
+    super.includes,
+    super.severity,
     this.utilsFolderPath = _defaultUtilsFolderPath,
   });
 
-  final ErrorSeverity? severity;
-  @override
-  final List<String> excludes;
-  @override
-  final List<String> includes;
   final String utilsFolderPath;
 
   static _UtilFunctionsMustBeStaticOption fromMap(Map<String, dynamic> map) {

--- a/super_lint/lib/src/utils/lint_extensions.dart
+++ b/super_lint/lib/src/utils/lint_extensions.dart
@@ -207,3 +207,29 @@ extension LintCodeCopyWith on LintCode {
         errorSeverity: errorSeverity ?? this.errorSeverity,
       );
 }
+
+class _RunContext<T extends CommonLintOption> {
+  const _RunContext(this.code, this.parameters);
+
+  final LintCode code;
+  final T parameters;
+}
+
+extension OptionsLintRuleRunExt<T extends CommonLintOption> on OptionsLintRule<T> {
+  Future<_RunContext<T>?> prepareRun(CustomLintResolver resolver) async {
+    final rootPath = await resolver.rootPath;
+    final parameters = config.parameters;
+    if (parameters.shouldSkipAnalysis(
+      path: resolver.path,
+      rootPath: rootPath,
+    )) {
+      return null;
+    }
+
+    final code = this.code.copyWith(
+      errorSeverity: parameters.severity ?? this.code.errorSeverity,
+    );
+
+    return _RunContext(code, parameters);
+  }
+}


### PR DESCRIPTION
## Summary
- add `CommonLintOption` for shared lint parameters
- factor out repeated run preparation into `prepareRun`
- inline lint names into `RuleConfig` constructors
- update all lint options to extend `CommonLintOption`

## Testing
- `dart format super_lint/lib/src/base/common_lint_option.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee319f1448326b27710169507b68c