### PR TITLE
Fix equalsIgnoreCase string extension

### DIFF
--- a/lib/common/util/extension.dart
+++ b/lib/common/util/extension.dart
@@ -141,7 +141,8 @@ extension StringExtensions on String {
 
   String? get firstOrNull => isNotEmpty ? this[0] : null;
 
-  bool equalsIgnoreCase(String secondString) => toLowerCase().contains(secondString.toLowerCase());
+  bool equalsIgnoreCase(String secondString) =>
+      toLowerCase() == secondString.toLowerCase();
 
   bool containsIgnoreCase(String secondString) =>
       toLowerCase().contains(secondString.toLowerCase());

--- a/test/unit_test/common/util/extension_test.dart
+++ b/test/unit_test/common/util/extension_test.dart
@@ -531,6 +531,12 @@ void main() {
         final result = string.equalsIgnoreCase('abcd');
         expect(result, false);
       });
+
+      test('when string is "abc" and other is "ab"', () {
+        const String string = 'abc';
+        final result = string.equalsIgnoreCase('ab');
+        expect(result, false);
+      });
     });
 
     group('containsIgnoreCase', () {


### PR DESCRIPTION
## Summary
- fix `equalsIgnoreCase` to compare entire strings rather than using `contains`
- add regression test for string equality ignoring case

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*


------
https://chatgpt.com/codex/tasks/task_e_689a1aa074a0832ea2596d8d25d12549